### PR TITLE
Use session cookies instead of manually including ID in requests

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -523,7 +523,6 @@ class CompileDDCResponse {
 class CompileRequest {
   /// Return the Dart to JS source map; optional (defaults to false).
   core.bool returnSourceMap;
-  core.String sessionId;
 
   /// The Dart source.
   core.String source;
@@ -533,9 +532,6 @@ class CompileRequest {
   CompileRequest.fromJson(core.Map _json) {
     if (_json.containsKey("returnSourceMap")) {
       returnSourceMap = _json["returnSourceMap"];
-    }
-    if (_json.containsKey("sessionId")) {
-      sessionId = _json["sessionId"];
     }
     if (_json.containsKey("source")) {
       source = _json["source"];
@@ -547,9 +543,6 @@ class CompileRequest {
         new core.Map<core.String, core.Object>();
     if (returnSourceMap != null) {
       _json["returnSourceMap"] = returnSourceMap;
-    }
-    if (sessionId != null) {
-      _json["sessionId"] = sessionId;
     }
     if (source != null) {
       _json["source"] = source;
@@ -785,7 +778,6 @@ class SourceEdit {
 class SourceRequest {
   /// An optional offset into the source code.
   core.int offset;
-  core.String sessionId;
 
   /// The Dart source.
   core.String source;
@@ -795,9 +787,6 @@ class SourceRequest {
   SourceRequest.fromJson(core.Map _json) {
     if (_json.containsKey("offset")) {
       offset = _json["offset"];
-    }
-    if (_json.containsKey("sessionId")) {
-      sessionId = _json["sessionId"];
     }
     if (_json.containsKey("source")) {
       source = _json["source"];
@@ -809,9 +798,6 @@ class SourceRequest {
         new core.Map<core.String, core.Object>();
     if (offset != null) {
       _json["offset"] = offset;
-    }
-    if (sessionId != null) {
-      _json["sessionId"] = sessionId;
     }
     if (source != null) {
       _json["source"] = source;

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "8d4d4001bad5c5000efabe673ed5320cd302b018",
+ "etag": "232e976c58a62c98f928c6aa18389b5477a868ab",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -17,10 +17,6 @@
    "id": "SourceRequest",
    "type": "object",
    "properties": {
-    "sessionId": {
-     "type": "string",
-     "required": true
-    },
     "source": {
      "type": "string",
      "description": "The Dart source.",
@@ -89,10 +85,6 @@
     "source": {
      "type": "string",
      "description": "The Dart source.",
-     "required": true
-    },
-    "sessionId": {
-     "type": "string",
      "required": true
     },
     "returnSourceMap": {

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -150,10 +150,11 @@ class EndpointsServer {
       final sessionId = cookies.get(CommonServer.sessionIdCookieName)?.value ?? Uuid().v4();
       final setCookie = Cookie(CommonServer.sessionIdCookieName, sessionId)
         ..maxAge = Duration(days: 365).inSeconds
+        ..httpOnly = true
         ..path = '/api';
 
       return Response(HttpStatus.ok,
-        headers: {HttpHeaders.setCookieHeader: '$setCookie'},
+        headers: {HttpHeaders.setCookieHeader: '$setCookie;SameSite=Strict'},
       );
     });
     router.get('/api/compiled_output/v1/session/<sessionId>/<path|.+>', (Request request, String sessionId, String path) {
@@ -203,7 +204,6 @@ Stack Trace: ${stackTrace.toString()}
 
   Middleware _createCustomCorsHeadersMiddleware() {
     return shelf_cors.createCorsHeadersMiddleware(corsHeaders: <String, String>{
-      'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Headers':
           'Origin, X-Requested-With, Content-Type, Accept, x-goog-api-client'

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -154,7 +154,7 @@ class EndpointsServer {
         ..path = '/api';
 
       return Response(HttpStatus.ok,
-        headers: {HttpHeaders.setCookieHeader: '$setCookie;SameSite=Strict'},
+        headers: {HttpHeaders.setCookieHeader: setCookie.toString()},
       );
     });
     router.get('/api/compiled_output/v1/session/<sessionId>/<path|.+>', (Request request, String sessionId, String path) {

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -56,14 +56,7 @@ class AnalysisIssue implements Comparable<AnalysisIssue> {
   String toString() => '$kind: $message [$line]';
 }
 
-abstract class BaseRequest {
-  String get sessionId;
-}
-
-class SourceRequest implements BaseRequest {
-  @ApiProperty(required: true)
-  String sessionId;
-
+class SourceRequest {
   @ApiProperty(required: true, description: 'The Dart source.')
   String source;
 
@@ -71,10 +64,7 @@ class SourceRequest implements BaseRequest {
   int offset;
 }
 
-class SourcesRequest implements BaseRequest {
-  @ApiProperty(required: true)
-  String sessionId;
-
+class SourcesRequest {
   @ApiProperty(required: true, description: 'Map of names to Sources.')
   Map<String, String> sources;
 
@@ -95,12 +85,9 @@ class Location {
   Location.from(this.sourceName, this.offset);
 }
 
-class CompileRequest implements BaseRequest {
+class CompileRequest {
   @ApiProperty(required: true, description: 'The Dart source.')
   String source;
-
-  @ApiProperty(required: true)
-  String sessionId;
 
   @ApiProperty(
       description:
@@ -115,10 +102,7 @@ class CompileResponse {
   CompileResponse(this.result, [this.sourceMap]);
 }
 
-class CompileDDCRequest implements BaseRequest {
-  @ApiProperty(required: true)
-  String sessionId;
-
+class CompileDDCRequest {
   @ApiProperty(required: true, description: 'The Dart source.')
   String source;
 }
@@ -129,10 +113,7 @@ class CompileDDCResponse {
   CompileDDCResponse(this.entrypointUrl);
 }
 
-class CounterRequest implements BaseRequest {
-  @ApiProperty(required: true)
-  String sessionId;
-
+class CounterRequest {
   @ApiProperty(required: true)
   String name;
 }

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -103,15 +103,6 @@ $_samplePackageName:lib/
         .writeAsString(pubspec);
 
     await _runPubGet();
-
-    final String sdkVersion = SdkManager.sdk.version;
-
-    // download and save the flutter_web.sum file
-    String url = 'https://storage.googleapis.com/compilation_artifacts/'
-        '$sdkVersion/flutter_web.sum';
-    Uint8List summaryContents = await http.readBytes(url);
-    await File(path.join(_projectDirectory.path, 'flutter_web.sum'))
-        .writeAsBytes(summaryContents);
   }
 
   String get summaryFilePath {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   path: ^1.6.2
   shelf: ^0.7.0
   shelf_router: ^0.7.1
+  shelf_cookie: ^1.1.1
   rpc: ^0.6.1
   uuid: ^2.0.0
   yaml: ^2.1.15


### PR DESCRIPTION
- Add `api/v1/session` endpoint, which creates a session if one does not already exist
   - The client will hit this before any other requests are made
- Update CORS handling to work with XHRs sending cookies via `withCredentials`